### PR TITLE
Hover related bug fixed

### DIFF
--- a/source/jquery.bxSlider.js
+++ b/source/jquery.bxSlider.js
@@ -406,7 +406,9 @@
 			if(typeof(changeText) == 'undefined'){
 				var changeText = true;
 			}
-			setAutoInterval();
+			if(autoPlaying){
+				setAutoInterval();
+			}
 			if(changeText && options.autoControls){
 				$autoControls.html($stopContent).removeClass('start').addClass('stop');
 			}
@@ -416,16 +418,16 @@
 		 * Stop the slideshow permanently
 		 */		
 		this.stopShow = function(changeText){
-			this.suspendShow(changeText);
 			autoPlaying = false;
+			this.suspendShow(changeText);
 		}
 		
 		/**
 		 * Start the slideshow
 		 */		
 		this.startShow = function(changeText){
-			this.restartShow(changeText);
 			autoPlaying = true;
+			this.restartShow(changeText);
 		}
 		
 		/**
@@ -577,6 +579,7 @@
 				// check if show should auto start
 				if(options.autoStart){
 					// check if autostart should delay
+					autoPlaying = false; // prevent playing during the deplay
 					setTimeout(function(){
 						base.startShow(true);
 					}, options.autoDelay);

--- a/source/jquery.bxSlider.js
+++ b/source/jquery.bxSlider.js
@@ -385,9 +385,9 @@
 		}
 		
 		/**
-		 * Stop the slideshow
+		 * Suspend the slideshow
 		 */		
-		this.stopShow = function(changeText){
+		this.suspendShow = function(changeText){
 			clearInterval(interval);
 			// check if changeText argument is supplied
 			if(typeof(changeText) == 'undefined'){
@@ -395,14 +395,13 @@
 			}
 			if(changeText && options.autoControls){
 				$autoControls.html($startContent).removeClass('stop').addClass('start');
-				autoPlaying = false;
 			}
 		}
 		
 		/**
-		 * Start the slideshow
+		 * Restart the suspended slideshow
 		 */		
-		this.startShow = function(changeText){
+		this.restartShow = function(changeText){
 			// check if changeText argument is supplied
 			if(typeof(changeText) == 'undefined'){
 				var changeText = true;
@@ -410,8 +409,23 @@
 			setAutoInterval();
 			if(changeText && options.autoControls){
 				$autoControls.html($stopContent).removeClass('start').addClass('stop');
-				autoPlaying = true;
 			}
+		}
+		
+		/**
+		 * Stop the slideshow permanently
+		 */		
+		this.stopShow = function(changeText){
+			this.suspendShow(changeText);
+			autoPlaying = false;
+		}
+		
+		/**
+		 * Start the slideshow
+		 */		
+		this.startShow = function(changeText){
+			this.restartShow(changeText);
+			autoPlaying = true;
 		}
 		
 		/**
@@ -889,11 +903,11 @@
 			// hover over the slider window
 			$outerWrapper.find('.bx-window').hover(function() {
 				if(autoPlaying){
-					base.stopShow(false);
+					base.suspendShow(false);
 				}
 			}, function() {
 				if(autoPlaying){
-					base.startShow(false);
+					base.restartShow(false);
 				}
 			});
 		}
@@ -905,11 +919,11 @@
 			// on hover stop the animation
 			$parent.hover(function() {
 				if(autoPlaying){
-					base.stopTicker(false);
+					base.suspendShow(false);
 				}
 			}, function() {
 				if(autoPlaying){
-					base.startTicker(false);
+					base.restartTicker(false);
 				}
 			});
 		}		


### PR DESCRIPTION
I've made changes to fix two bugs related to the hover event when auto play is enabled:
1. Calling stopShow() and then performing a mouseout event would restart the show. I believe the intention is for stopShow() to permanently stop the show until startShow() is called.
2. Performing a mouseout during the initial auto delay (using the autoDelay configuration option) would allow multiple auto intervals to be set. This can cause erratic changing of the slides.

This biggest change that I made was to create suspend/restart functions. These now do most of the work that the start/stop functions were doing before. This separation was needed to distinguish between suspending the slideshow during mouseover and permanently stopping it. This does not change the public API and should be seamless to the end user.

-Nick
