### PR TITLE
Fixes scrolling after last slide when options.displaySlideQty > 1

### DIFF
--- a/source/jquery.bxSlider.js
+++ b/source/jquery.bxSlider.js
@@ -512,7 +512,7 @@
 			tickerTop = 0;
       
 			firstSlide = 0;
-			lastSlide = $children.length - 1;
+			lastSlide = $children.length - options.displaySlideQty;
 						
 			// get the largest child's height and width
 			$children.each(function(index) {


### PR DESCRIPTION
When a display slide quantity is more than 1, the slider will still slide after the last slide
