### PR TITLE
Changed getSlidePosition() to check for only immediate children of the $parent instead of grabbing all instances of .pager.

### DIFF
--- a/source/jquery.bxSlider.js
+++ b/source/jquery.bxSlider.js
@@ -1158,11 +1158,11 @@
 		/**
 		 * Returns the left offset of the slide from the parent container
 		 */		
-		function getSlidePosition(number, side){			
+		function getSlidePosition(number, side){						
 			if(side == 'left'){
-				var position = $('.pager', $outerWrapper).eq(number).position().left;
+				var position = $parent.find(' > .pager').eq(number).position().left;
 			}else if(side == 'top'){
-				var position = $('.pager', $outerWrapper).eq(number).position().top;
+				var position = $parent.find(' > .pager').eq(number).position().left;
 			}
 			return position;
 		}


### PR DESCRIPTION
This allows you to inception the sliders.
